### PR TITLE
Increase available memory

### DIFF
--- a/uml-run.sh
+++ b/uml-run.sh
@@ -73,7 +73,7 @@ echo "[*] Booting kernel ${KERNEL}"
 	"root=98:0" \
 	"rw" \
 	"console=tty0" \
-	"mem=128M" \
+	"mem=256M" \
 	"quiet" \
 	"SYSTEMD_UNIT_PATH=${BASE_DIR}/guest/systemd" \
 	"PATH=${BASE_DIR}/guest:${PATH:-/usr/bin}" \


### PR DESCRIPTION
Increase available memory to avoid systemd issue with Ubuntu 24:

  Out of memory: Killed process 20 ((sd-exec-strv)) total-vm:19496kB, anon-rss:1284kB, file-rss:0kB, shmem-rss:0kB, UID:0 pgtables:52kB oom_score_adj:0
  systemd[1]: Failed to fork off sandboxing environment for executing generators: Protocol error

See https://github.com/landlock-lsm/rust-landlock/actions/runs/14361251529/job/40263275363?pr=88