### PR TITLE
Set up 9p and FUSE mount points

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ cd linux
 
 In order to test more filesystems, these commands should be installed:
 * [diod](https://github.com/chaos/diod) (9p filesystem)
+* [bindfs](https://github.com/mpartel/bindfs) (FUSE filesystem)
 
 ## rust-landlock
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ cd linux
 .../check-linux.sh build kselftest kunit
 ```
 
+### Optional dependencies
+
+In order to test more filesystems, these commands should be installed:
+* [diod](https://github.com/chaos/diod) (9p filesystem)
+
 ## rust-landlock
 
 test-rust.sh can be used to test the Landlock crate against a specific kernel

--- a/guest/init.sh
+++ b/guest/init.sh
@@ -85,6 +85,15 @@ else
 	echo "WARNING: Could not find the diod command." >&2
 fi
 
+if command -v bindfs >/dev/null; then
+	mkdir /mnt/test-fuse-src
+	chmod 1777 /mnt/test-fuse-src
+	mkdir /mnt/test-fuse
+	bindfs /mnt/test-fuse-src /mnt/test-fuse
+else
+	echo "WARNING: Could not find the bindfs command." >&2
+fi
+
 cd "${TEST_CWD}"
 
 # Keeps root's capabilities but switches to the current user.

--- a/guest/init.sh
+++ b/guest/init.sh
@@ -69,6 +69,22 @@ if [[ -z "${TMPDIR:-}" ]]; then
 	export TMPDIR="/tmp"
 fi
 
+if [[ ! -d /mnt ]]; then
+	mkdir /mnt
+fi
+mount -t tmpfs -o "mode=755,nosuid,nodev" tmpfs /mnt
+
+if command -v diod >/dev/null; then
+	mkdir /mnt/test-v9fs-src
+	chmod 1777 /mnt/test-v9fs-src
+	mkdir /mnt/test-v9fs
+	# Listen on the 9pfs port.
+	diod -n -l 127.0.0.1:564 -e /mnt/test-v9fs-src
+	mount.diod -n 127.0.0.1:/mnt/test-v9fs-src /mnt/test-v9fs
+else
+	echo "WARNING: Could not find the diod command." >&2
+fi
+
 cd "${TEST_CWD}"
 
 # Keeps root's capabilities but switches to the current user.


### PR DESCRIPTION
Mounting such filesystems from the test fixtures is not simple because of the daemons' lifetime, and it requires installed programs anyway.