### PR TITLE
Add missing llvm-gcov.sh

### DIFF
--- a/llvm-gcov.sh
+++ b/llvm-gcov.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec llvm-cov gcov "$@"


### PR DESCRIPTION
Fixes: 4cb01ff9bbe6 ("check-linux: Get test coverage on x86_64")

See #23